### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -13,7 +13,7 @@ entries:
     - https://github.com/summerwind/actions-runner-controller
     type: application
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/actions-runner-controller-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/actions-runner-controller-0.1.0.tgz
     version: 0.1.0
   app-mesh-app:
   - apiVersion: v1
@@ -37,7 +37,7 @@ entries:
     sources:
     - https://github.com/giantswarm/app-mesh-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/app-mesh-app-0.4.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/app-mesh-app-0.4.0.tgz
     version: 0.4.0
   app-updater-app:
   - apiVersion: v1
@@ -49,7 +49,7 @@ entries:
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     name: app-updater-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/app-updater-app-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/app-updater-app-0.1.0.tgz
     version: 0.1.0
   aws-ebs-csi-driver-app:
   - apiVersion: v1
@@ -76,7 +76,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v1.7.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.7.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.7.1.tgz
     version: 1.7.1
   - apiVersion: v1
     appVersion: 0.9.0
@@ -89,7 +89,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v1.7.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.7.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.7.0.tgz
     version: 1.7.0
   - apiVersion: v1
     appVersion: 0.9.0
@@ -102,7 +102,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v1.6.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.6.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.6.0.tgz
     version: 1.6.0
   - apiVersion: v1
     appVersion: 0.9.0
@@ -115,7 +115,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v1.5.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.5.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.5.0.tgz
     version: 1.5.0
   - apiVersion: v1
     appVersion: 0.9.0
@@ -128,7 +128,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v1.4.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.4.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.4.0.tgz
     version: 1.4.0
   - apiVersion: v1
     appVersion: 0.8.3
@@ -141,7 +141,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v1.3.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.3.0.tgz
     version: 1.3.0
   - apiVersion: v1
     appVersion: 0.8.1
@@ -154,7 +154,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v1.2.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.2.0.tgz
     version: 1.2.0
   - apiVersion: v1
     appVersion: 0.7.1
@@ -167,7 +167,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v1.0.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.0.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-ebs-csi-driver-app-1.0.0.tgz
     version: 1.0.0
   aws-efs-csi-driver:
   - apiVersion: v1
@@ -194,7 +194,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-efs-csi-driver-app/v0.0.7/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.7.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.7.tgz
     version: 0.0.7
   - apiVersion: v1
     appVersion: 1.1.0
@@ -207,7 +207,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-efs-csi-driver-app/v0.0.6/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.6.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.6.tgz
     version: 0.0.6
   - apiVersion: v1
     appVersion: 1.0.0
@@ -220,7 +220,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-efs-csi-driver-app/v0.0.5/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.5.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.5.tgz
     version: 0.0.5
   - apiVersion: v1
     appVersion: 1.0.0
@@ -233,7 +233,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v0.0.4/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.4.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.4.tgz
     version: 0.0.4
   - apiVersion: v1
     appVersion: 1.0.0
@@ -246,7 +246,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v0.0.3/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.3.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.3.tgz
     version: 0.0.3
   - apiVersion: v1
     appVersion: 1.0.0
@@ -259,7 +259,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v0.0.2/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.2.tgz
     version: 0.0.2
   - apiVersion: v1
     appVersion: 1.0.0
@@ -272,7 +272,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v0.0.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/aws-efs-csi-driver-0.0.1.tgz
     version: 0.0.1
   azure-ad-pod-identity-app:
   - annotations:
@@ -371,7 +371,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/azure-ad-pod-identity-app/v0.2.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/azure-ad-pod-identity-app-0.2.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/azure-ad-pod-identity-app-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v1
     appVersion: 1.6.1
@@ -383,7 +383,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/azure-ad-pod-identity-app/v0.2.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/azure-ad-pod-identity-app-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/azure-ad-pod-identity-app-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
     appVersion: 1.6.1
@@ -396,7 +396,7 @@ entries:
     - https://github.com/Azure/aad-pod-identity
     - https://github.com/giantswarm/azure-ad-pod-identity-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/azure-ad-pod-identity-app-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/azure-ad-pod-identity-app-0.1.0.tgz
     version: 0.1.0
   eventrouter-app:
   - apiVersion: v1
@@ -417,7 +417,7 @@ entries:
     - https://github.com/heptiolabs/eventrouter
     - https://github.com/giantswarm/eventrouter-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/eventrouter-app-0.0.4.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/eventrouter-app-0.0.4.tgz
     version: 0.0.4
   - apiVersion: v1
     appVersion: v0.3
@@ -437,7 +437,7 @@ entries:
     - https://github.com/heptiolabs/eventrouter
     - https://github.com/giantswarm/eventrouter-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/eventrouter-app-0.0.3.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/eventrouter-app-0.0.3.tgz
     version: 0.0.3
   - apiVersion: v1
     appVersion: v0.3
@@ -456,7 +456,7 @@ entries:
     - https://github.com/heptiolabs/eventrouter
     - https://github.com/giantswarm/eventrouter-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/eventrouter-app-0.0.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/eventrouter-app-0.0.2.tgz
     version: 0.0.2
   - apiVersion: v1
     appVersion: v0.0.1
@@ -474,7 +474,7 @@ entries:
     - https://github.com/heptiolabs/eventrouter
     - https://github.com/giantswarm/eventrouter-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/eventrouter-app-0.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/eventrouter-app-0.0.1.tgz
     version: 0.0.1
   fluent-logshipping-app:
   - apiVersion: v1
@@ -488,7 +488,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.6.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.6.0.tgz
     version: 0.6.0
   - apiVersion: v1
     appVersion: 0.5.5
@@ -501,7 +501,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.5.5.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.5.5.tgz
     version: 0.5.5
   - apiVersion: v1
     appVersion: 0.5.4
@@ -514,7 +514,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.5.4.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.5.4.tgz
     version: 0.5.4
   - apiVersion: v1
     appVersion: 0.5.3
@@ -527,7 +527,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.5.3.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.5.3.tgz
     version: 0.5.3
   - apiVersion: v1
     appVersion: 0.5.2
@@ -540,7 +540,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.5.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.5.2.tgz
     version: 0.5.2
   - apiVersion: v1
     appVersion: v0.4.0
@@ -553,7 +553,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.5.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.5.1.tgz
     version: 0.5.1
   - apiVersion: v1
     appVersion: v0.4.0
@@ -566,7 +566,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.5.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.5.0.tgz
     version: 0.5.0
   - apiVersion: v1
     appVersion: v0.4.0
@@ -579,7 +579,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.4.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
     appVersion: v0.3.0
@@ -592,7 +592,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
     appVersion: v0.2.1
@@ -605,7 +605,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.2.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v1
     appVersion: v0.2.0
@@ -618,7 +618,7 @@ entries:
     sources:
     - https://github.com/giantswarm/fluent-logshipping-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/fluent-logshipping-app-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/fluent-logshipping-app-0.2.0.tgz
     version: 0.2.0
   flux-app:
   - annotations:
@@ -636,7 +636,7 @@ entries:
     sources:
     - https://github.com/fluxcd/flux2
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/flux-app-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/flux-app-0.1.0.tgz
     version: 0.1.0
   gatling-app:
   - apiVersion: v1
@@ -651,7 +651,7 @@ entries:
     - https://raw.githubusercontent.com/giantswarm/gatling-app/v1.0.2/README.md
     - https://github.com/gatling/gatling
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/gatling-app-1.0.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/gatling-app-1.0.2.tgz
     version: 1.0.2
   - apiVersion: v1
     appVersion: 3.2.1
@@ -665,7 +665,7 @@ entries:
     - https://raw.githubusercontent.com/giantswarm/gatling-app/v1.0.1/README.md
     - https://github.com/gatling/gatling
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/gatling-app-1.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/gatling-app-1.0.1.tgz
     version: 1.0.1
   - apiVersion: v1
     appVersion: 3.2.1
@@ -679,7 +679,7 @@ entries:
     - https://raw.githubusercontent.com/giantswarm/gatling-app/v1.0.0/README.md
     - https://github.com/gatling/gatling
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/gatling-app-1.0.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/gatling-app-1.0.0.tgz
     version: 1.0.0
   giantswarm-todo-app:
   - apiVersion: v1
@@ -702,7 +702,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.5.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.5.2.tgz
     version: 0.5.2
   - apiVersion: v1
     appVersion: 0.5.1
@@ -724,7 +724,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.5.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.5.1.tgz
     version: 0.5.1
   - apiVersion: v1
     appVersion: 0.4.1
@@ -746,7 +746,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.4.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.4.1.tgz
     version: 0.4.1
   - apiVersion: v1
     appVersion: 0.3.3
@@ -768,7 +768,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.3.3.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.3.3.tgz
     version: 0.3.3
   - apiVersion: v1
     appVersion: 0.3.2
@@ -790,7 +790,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.3.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.3.2.tgz
     version: 0.3.2
   - apiVersion: v1
     appVersion: 0.3.1
@@ -808,7 +808,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.3.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.3.1.tgz
     version: 0.3.1
   - apiVersion: v1
     appVersion: 0.2.9
@@ -826,7 +826,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.2.9.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.2.9.tgz
     version: 0.2.9
   - apiVersion: v1
     appVersion: 0.2.8
@@ -844,7 +844,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.2.8.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.2.8.tgz
     version: 0.2.8
   - apiVersion: v1
     appVersion: 0.2.7
@@ -862,7 +862,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.2.7.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.2.7.tgz
     version: 0.2.7
   - apiVersion: v1
     appVersion: 0.2.6
@@ -880,7 +880,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.2.6.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.2.6.tgz
     version: 0.2.6
   - apiVersion: v1
     appVersion: 0.2.5
@@ -898,7 +898,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.2.5.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.2.5.tgz
     version: 0.2.5
   - apiVersion: v1
     appVersion: 0.2.4
@@ -915,7 +915,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.2.4.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.2.4.tgz
     version: 0.2.4
   - apiVersion: v1
     appVersion: 0.2.3
@@ -932,7 +932,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.2.3.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.2.3.tgz
     version: 0.2.3
   - apiVersion: v1
     appVersion: 0.2.2
@@ -949,7 +949,7 @@ entries:
     - https://github.com/giantswarm/blog-i-want-it-all
     - https://github.com/giantswarm/giantswarm-todo-app/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.2.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.2.2.tgz
     version: 0.2.2
   - apiVersion: v1
     appVersion: 0.1.4
@@ -965,7 +965,7 @@ entries:
     sources:
     - https://github.com/giantswarm/blog-i-want-it-all
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/giantswarm-todo-app-0.1.4.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/giantswarm-todo-app-0.1.4.tgz
     version: 0.1.4
   goldilocks-app:
   - apiVersion: v2
@@ -998,7 +998,7 @@ entries:
     sources:
     - https://github.com/inlets/inlets
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/inlets-operator-app-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/inlets-operator-app-0.1.0.tgz
     version: 0.1.0
   istio-operator:
   - apiVersion: v1
@@ -1012,7 +1012,7 @@ entries:
     sources:
     - https://github.com/istio/istio/operator
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/istio-operator-1.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/istio-operator-1.0.1.tgz
     version: 1.0.1
   - apiVersion: v1
     appVersion: v1.6.0
@@ -1025,7 +1025,7 @@ entries:
     sources:
     - https://github.com/istio/istio/operator
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/istio-operator-1.0.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/istio-operator-1.0.0.tgz
     version: 1.0.0
   jaeger-operator-app:
   - annotations:
@@ -1080,7 +1080,7 @@ entries:
     - https://raw.githubusercontent.com/giantswarm/jaeger-operator-app/v[[ .Version
       ]]/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/jaeger-operator-app-0.2.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/jaeger-operator-app-0.2.2.tgz
     version: 0.2.2
   - apiVersion: v1
     appVersion: 1.18.0
@@ -1101,7 +1101,7 @@ entries:
     - https://github.com/giantswarm/jaeger-operator-app
     - https://raw.githubusercontent.com/giantswarm/jaeger-operator-app/v0.2.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/jaeger-operator-app-0.2.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/jaeger-operator-app-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v1
     appVersion: 1.18.0
@@ -1122,7 +1122,7 @@ entries:
     - https://github.com/giantswarm/jaeger-operator-app
     - https://raw.githubusercontent.com/giantswarm/jaeger-operator-app/v0.2.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/jaeger-operator-app-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/jaeger-operator-app-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
     appVersion: 1.17.1
@@ -1141,7 +1141,7 @@ entries:
     - https://github.com/giantswarm/jaeger-operator-app
     - https://raw.githubusercontent.com/giantswarm/jaeger-operator-app/v0.1.2/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/jaeger-operator-app-0.1.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/jaeger-operator-app-0.1.2.tgz
     version: 0.1.2
   - apiVersion: v1
     appVersion: 1.17.1
@@ -1159,7 +1159,7 @@ entries:
     sources:
     - https://github.com/giantswarm/jaeger-operator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/jaeger-operator-app-0.1.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/jaeger-operator-app-0.1.1.tgz
     version: 0.1.1
   k8s-audit-metrics:
   - apiVersion: v1
@@ -1170,7 +1170,7 @@ entries:
     home: https://github.com/giantswarm/k8s-audit-metrics
     name: k8s-audit-metrics
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-audit-metrics-0.0.7.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-audit-metrics-0.0.7.tgz
     version: 0.0.7
   - apiVersion: v1
     appVersion: 0.0.6
@@ -1180,7 +1180,7 @@ entries:
     home: https://github.com/giantswarm/k8s-audit-metrics
     name: k8s-audit-metrics
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-audit-metrics-0.0.6.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-audit-metrics-0.0.6.tgz
     version: 0.0.6
   - apiVersion: v1
     appVersion: 0.0.5
@@ -1190,7 +1190,7 @@ entries:
     home: https://github.com/giantswarm/k8s-audit-metrics
     name: k8s-audit-metrics
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-audit-metrics-0.0.5.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-audit-metrics-0.0.5.tgz
     version: 0.0.5
   - apiVersion: v1
     appVersion: 0.0.4
@@ -1200,7 +1200,7 @@ entries:
     home: https://github.com/giantswarm/k8s-audit-metrics
     name: k8s-audit-metrics
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-audit-metrics-0.0.4.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-audit-metrics-0.0.4.tgz
     version: 0.0.4
   - apiVersion: v1
     appVersion: 0.0.3
@@ -1210,7 +1210,7 @@ entries:
     home: https://github.com/giantswarm/k8s-audit-metrics
     name: k8s-audit-metrics
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-audit-metrics-0.0.3.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-audit-metrics-0.0.3.tgz
     version: 0.0.3
   - apiVersion: v1
     appVersion: 0.0.2
@@ -1220,7 +1220,7 @@ entries:
     home: https://github.com/giantswarm/k8s-audit-metrics
     name: k8s-audit-metrics
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-audit-metrics-0.0.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-audit-metrics-0.0.2.tgz
     version: 0.0.2
   - apiVersion: v1
     appVersion: 0.0.1
@@ -1230,7 +1230,7 @@ entries:
     home: https://github.com/giantswarm/k8s-audit-metrics
     name: k8s-audit-metrics
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-audit-metrics-0.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-audit-metrics-0.0.1.tgz
     version: 0.0.1
   k8s-initiator-app:
   - apiVersion: v1
@@ -1246,7 +1246,7 @@ entries:
     - https://github.com/giantswarm/k8s-initiator-app
     - https://raw.githubusercontent.com/giantswarm/k8s-initiator-app/v0.9.2/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.9.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.9.2.tgz
     version: 0.9.2
   - apiVersion: v1
     appVersion: v0.9.0
@@ -1260,7 +1260,7 @@ entries:
     sources:
     - https://github.com/giantswarm/k8s-initiator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.9.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.9.1.tgz
     version: 0.9.1
   - apiVersion: v1
     appVersion: v0.9.0
@@ -1274,7 +1274,7 @@ entries:
     sources:
     - https://github.com/giantswarm/k8s-initiator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.9.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.9.0.tgz
     version: 0.9.0
   - apiVersion: v1
     appVersion: v0.3.0
@@ -1288,7 +1288,7 @@ entries:
     sources:
     - https://github.com/giantswarm/k8s-initiator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.8.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.8.0.tgz
     version: 0.8.0
   - apiVersion: v1
     appVersion: v0.3.0
@@ -1302,7 +1302,7 @@ entries:
     sources:
     - https://github.com/giantswarm/k8s-initiator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.7.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.7.0.tgz
     version: 0.7.0
   - apiVersion: v1
     appVersion: v0.3.0
@@ -1316,7 +1316,7 @@ entries:
     sources:
     - https://github.com/giantswarm/k8s-initiator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.6.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.6.0.tgz
     version: 0.6.0
   - apiVersion: v1
     appVersion: v0.3.0
@@ -1330,7 +1330,7 @@ entries:
     sources:
     - https://github.com/giantswarm/k8s-initiator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.5.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.5.0.tgz
     version: 0.5.0
   - apiVersion: v1
     appVersion: v0.3.0
@@ -1344,7 +1344,7 @@ entries:
     sources:
     - https://github.com/giantswarm/k8s-initiator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.4.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
     appVersion: v0.3.0
@@ -1358,7 +1358,7 @@ entries:
     sources:
     - https://github.com/giantswarm/k8s-initiator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
     appVersion: v0.2.0
@@ -1372,7 +1372,7 @@ entries:
     sources:
     - https://github.com/giantswarm/k8s-initiator-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/k8s-initiator-app-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/k8s-initiator-app-0.2.0.tgz
     version: 0.2.0
   keda:
   - annotations:
@@ -1397,7 +1397,7 @@ entries:
     sources:
     - https://github.com/kedacore/keda
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/keda-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/keda-0.1.0.tgz
     version: 0.1.0
   kibana-oss-app:
   - apiVersion: v1
@@ -1417,7 +1417,7 @@ entries:
     - https://github.com/elastic/helm-charts/tree/master/kibana
     - https://github.com/giantswarm/kibana-oss-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kibana-oss-app-0.0.6.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kibana-oss-app-0.0.6.tgz
     version: 0.0.6
   - apiVersion: v1
     appVersion: v0.1
@@ -1435,7 +1435,7 @@ entries:
     - https://github.com/elastic/helm-charts/tree/master/kibana
     - https://github.com/giantswarm/kibana-oss-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kibana-oss-app-0.0.5.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kibana-oss-app-0.0.5.tgz
     version: 0.0.5
   - apiVersion: v1
     appVersion: v0.1
@@ -1453,7 +1453,7 @@ entries:
     - https://github.com/elastic/helm-charts/tree/master/kibana
     - https://github.com/giantswarm/kibana-oss-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kibana-oss-app-0.0.4.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kibana-oss-app-0.0.4.tgz
     version: 0.0.4
   - apiVersion: v1
     appVersion: v0.1
@@ -1471,7 +1471,7 @@ entries:
     - https://github.com/elastic/helm-charts/tree/master/kibana
     - https://github.com/giantswarm/kibana-oss-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kibana-oss-app-0.0.3.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kibana-oss-app-0.0.3.tgz
     version: 0.0.3
   - apiVersion: v1
     appVersion: v0.1
@@ -1489,7 +1489,7 @@ entries:
     - https://github.com/elastic/helm-charts/tree/master/kibana
     - https://github.com/giantswarm/kibana-oss-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kibana-oss-app-0.0.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kibana-oss-app-0.0.2.tgz
     version: 0.0.2
   - apiVersion: v1
     appVersion: v0.1
@@ -1507,7 +1507,7 @@ entries:
     - https://github.com/elastic/helm-charts/tree/master/kibana
     - https://github.com/giantswarm/kibana-oss-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kibana-oss-app-0.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kibana-oss-app-0.0.1.tgz
     version: 0.0.1
   - apiVersion: v1
     appVersion: v0.1
@@ -1525,7 +1525,7 @@ entries:
     - https://github.com/elastic/helm-charts/tree/master/kibana
     - https://github.com/giantswarm/kibana-oss-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kibana-oss-app-0.0.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kibana-oss-app-0.0.0.tgz
     version: 0.0.0
   kube-bench-app:
   - apiVersion: v2
@@ -1553,7 +1553,7 @@ entries:
     sources:
     - https://github.com/giantswarm/kubernetes-gpu
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kubernetes-gpu-app-440.82.03.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kubernetes-gpu-app-440.82.03.tgz
     version: 440.82.03
   - apiVersion: v1
     appVersion: 440.82.2
@@ -1565,7 +1565,7 @@ entries:
     sources:
     - https://github.com/giantswarm/kubernetes-gpu
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kubernetes-gpu-app-440.82.02.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kubernetes-gpu-app-440.82.02.tgz
     version: 440.82.02
   - apiVersion: v1
     appVersion: 440.82.1
@@ -1577,7 +1577,7 @@ entries:
     sources:
     - https://github.com/giantswarm/kubernetes-gpu
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kubernetes-gpu-app-440.82.01.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kubernetes-gpu-app-440.82.01.tgz
     version: 440.82.01
   - apiVersion: v1
     appVersion: "440.82"
@@ -1589,7 +1589,7 @@ entries:
     sources:
     - https://github.com/giantswarm/kubernetes-gpu
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kubernetes-gpu-app-440.82.00.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kubernetes-gpu-app-440.82.00.tgz
     version: 440.82.00
   - apiVersion: v1
     appVersion: "390.116"
@@ -1601,7 +1601,7 @@ entries:
     sources:
     - https://github.com/giantswarm/kubernetes-gpu
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/kubernetes-gpu-app-390.116.00.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/kubernetes-gpu-app-390.116.00.tgz
     version: 390.116.00
   linkerd2-app:
   - apiVersion: v1
@@ -1626,7 +1626,7 @@ entries:
     - https://github.com/linkerd/linkerd2/
     - https://github.com/giantswarm/linkerd2-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-app-0.4.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-app-0.4.1.tgz
     version: 0.4.1
   - apiVersion: v1
     appVersion: stable-2.8.1
@@ -1650,7 +1650,7 @@ entries:
     - https://github.com/linkerd/linkerd2/
     - https://github.com/giantswarm/linkerd2-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-app-0.4.1-bbdca58cee67f8fe5e73c9b30f5155e15beb33be.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-app-0.4.1-bbdca58cee67f8fe5e73c9b30f5155e15beb33be.tgz
     version: 0.4.1-bbdca58cee67f8fe5e73c9b30f5155e15beb33be
   - apiVersion: v1
     appVersion: stable-2.8.1
@@ -1674,7 +1674,7 @@ entries:
     - https://github.com/linkerd/linkerd2/
     - https://github.com/giantswarm/linkerd2-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-app-0.4.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-app-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
     appVersion: stable-2.7.1
@@ -1698,7 +1698,7 @@ entries:
     - https://github.com/linkerd/linkerd2/
     - https://github.com/giantswarm/linkerd2-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-app-0.3.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-app-0.3.2.tgz
     version: 0.3.2
   - apiVersion: v1
     appVersion: stable-2.7.1
@@ -1722,7 +1722,7 @@ entries:
     - https://github.com/linkerd/linkerd2/
     - https://github.com/giantswarm/linkerd2-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-app-0.3.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-app-0.3.1.tgz
     version: 0.3.1
   - apiVersion: v1
     appVersion: edge-19.11.2
@@ -1746,7 +1746,7 @@ entries:
     - https://github.com/linkerd/linkerd2/
     - https://github.com/giantswarm/linkerd2-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-app-0.2.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-app-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v1
     appVersion: edge-19.11.2
@@ -1767,7 +1767,7 @@ entries:
     sources:
     - https://github.com/linkerd/linkerd2/
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-app-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-app-0.1.0.tgz
     version: 0.1.0
   linkerd2-cni-app:
   - apiVersion: v1
@@ -1793,7 +1793,7 @@ entries:
     - https://github.com/linkerd/linkerd2
     - https://github.com/giantswarm/linkerd2-cni-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-cni-app-0.2.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-cni-app-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v1
     appVersion: 0.0.1
@@ -1818,7 +1818,7 @@ entries:
     - https://github.com/linkerd/linkerd2
     - https://github.com/giantswarm/linkerd2-cni-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-cni-app-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-cni-app-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
     appVersion: 0.1.0
@@ -1839,7 +1839,7 @@ entries:
     - https://github.com/linkerd/linkerd2
     - https://github.com/giantswarm/linkerd2-cni-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/linkerd2-cni-app-0.1.0-alpha.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/linkerd2-cni-app-0.1.0-alpha.tgz
     version: 0.1.0-alpha
   loki-stack-app:
   - apiVersion: v1
@@ -1869,7 +1869,7 @@ entries:
     - https://github.com/grafana/loki
     - https://github.com/giantswarm/loki-stack-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/loki-stack-app-0.2.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/loki-stack-app-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v1
     appVersion: v1.2.0
@@ -1889,7 +1889,7 @@ entries:
     - https://github.com/grafana/loki
     - https://github.com/giantswarm/loki-stack-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/loki-stack-app-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/loki-stack-app-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
     appVersion: v1.0.0
@@ -1906,7 +1906,7 @@ entries:
     sources:
     - https://github.com/grafana/loki
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/loki-stack-app-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/loki-stack-app-0.1.0.tgz
     version: 0.1.0
   opencensus-collector-app:
   - apiVersion: v1
@@ -1932,7 +1932,7 @@ entries:
     sources:
     - https://github.com/giantswarm/opencensus-collector-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/opencensus-collector-app-0.1.4.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/opencensus-collector-app-0.1.4.tgz
     version: 0.1.4
   - apiVersion: v1
     appVersion: 0.1.11
@@ -1957,7 +1957,7 @@ entries:
     sources:
     - https://github.com/giantswarm/opencensus-collector-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/opencensus-collector-app-0.1.3.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/opencensus-collector-app-0.1.3.tgz
     version: 0.1.3
   - apiVersion: v1
     appVersion: 0.1.11
@@ -1982,7 +1982,7 @@ entries:
     sources:
     - https://github.com/giantswarm/opencensus-collector-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/opencensus-collector-app-0.1.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/opencensus-collector-app-0.1.2.tgz
     version: 0.1.2
   - apiVersion: v1
     appVersion: 0.1.11
@@ -2007,7 +2007,7 @@ entries:
     sources:
     - https://github.com/giantswarm/opencensus-collector-app
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/opencensus-collector-app-0.1.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/opencensus-collector-app-0.1.1.tgz
     version: 0.1.1
   strimzi-kafka-operator-app:
   - apiVersion: v1
@@ -2042,7 +2042,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/strimzi-kafka-operator-app/v0.1.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/strimzi-kafka-operator-app-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/strimzi-kafka-operator-app-0.1.0.tgz
     version: 0.1.0
   - apiVersion: v1
     appVersion: 0.18.0
@@ -2059,7 +2059,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/strimzi-kafka-operator-app/v0.0.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/strimzi-kafka-operator-app-0.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/strimzi-kafka-operator-app-0.0.1.tgz
     version: 0.0.1
   velero:
   - annotations:
@@ -2088,7 +2088,7 @@ entries:
     - https://github.com/vmware-tanzu/velero
     type: application
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/velero-0.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/velero-0.0.1.tgz
     version: 0.0.1
   vertical-pod-autoscaler-app:
   - annotations:
@@ -2151,7 +2151,7 @@ entries:
     sources:
     - https://github.com/kubernetes/autoscaler
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/vertical-pod-autoscaler-app-1.0.3.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/vertical-pod-autoscaler-app-1.0.3.tgz
     version: 1.0.3
   - apiVersion: v1
     appVersion: 0.8.0
@@ -2163,7 +2163,7 @@ entries:
     sources:
     - https://github.com/kubernetes/autoscaler
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/vertical-pod-autoscaler-app-1.0.2.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/vertical-pod-autoscaler-app-1.0.2.tgz
     version: 1.0.2
   - apiVersion: v1
     appVersion: 0.8.0
@@ -2175,7 +2175,7 @@ entries:
     sources:
     - https://github.com/kubernetes/autoscaler
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/vertical-pod-autoscaler-app-1.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/vertical-pod-autoscaler-app-1.0.1.tgz
     version: 1.0.1
   - apiVersion: v1
     appVersion: 0.8.0
@@ -2187,6 +2187,6 @@ entries:
     sources:
     - https://github.com/kubernetes/autoscaler
     urls:
-    - https://giantswarm.github.com/giantswarm-playground-catalog/vertical-pod-autoscaler-app-1.0.0.tgz
+    - https://giantswarm.github.io/giantswarm-playground-catalog/vertical-pod-autoscaler-app-1.0.0.tgz
     version: 1.0.0
 generated: "2021-04-06T08:51:19.111859684Z"


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898